### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/examples/opf/experiments/params/EnsembleOnline.py
+++ b/examples/opf/experiments/params/EnsembleOnline.py
@@ -155,12 +155,12 @@ def getFieldPermutations(config, predictedField):
   encoders=config['modelParams']['sensorParams']['encoders']
   encoderList=[]
   for encoder in encoders:
-    if encoder==None:
+    if encoderisNone:
       continue
     if encoder['name']==predictedField:
       encoderList.append([encoder])
       for e in encoders:
-        if e==None:
+        if eisNone:
           continue
         if e['name'] != predictedField:
           encoderList.append([encoder, e])

--- a/examples/prediction/experiments/confidenceTest/base/description.py
+++ b/examples/prediction/experiments/confidenceTest/base/description.py
@@ -104,12 +104,12 @@ updateConfigFromSubConfig(config)
 if config['dataSetPackage'] is not None:
   assert (config['filenameTrain'] == 'confidence/confidence1.csv')
   assert (config['filenameTest'] == 'confidence/confidence1.csv')
-  assert (config['filenameCategory'] == None)
-  assert (config['dataGenScript'] == None)
-  assert (config['dataDesc'] == None)
-  assert (config['dataGenNumCategories'] == None)
-  assert (config['dataGenNumTraining'] == None)
-  assert (config['dataGenNumTesting'] == None)
+  assert (config['filenameCategory'] is None)
+  assert (config['dataGenScript'] is None)
+  assert (config['dataDesc'] is None)
+  assert (config['dataGenNumCategories'] is None)
+  assert (config['dataGenNumTraining'] is None)
+  assert (config['dataGenNumTesting'] is None)
   
   if config['dataSetPackage'] == 'firstOrder':
     config['filenameTrain'] = 'extra/firstOrder/fo_1000_10_train_resets.csv'

--- a/examples/tp/tp_overlapping_sequences.py
+++ b/examples/tp/tp_overlapping_sequences.py
@@ -360,7 +360,7 @@ def evalSequences(tps,
   """
 
   # If no test sequence is specified, use the first training sequence
-  if testSequences == None:
+  if testSequences is None:
     testSequences = trainingSequences
 
   # First TP instance is used by default for verbose printing of input values,

--- a/examples/tp/tp_segment_learning.py
+++ b/examples/tp/tp_segment_learning.py
@@ -315,7 +315,7 @@ class ExperimentTestBaseClass(testcasebase.TestCaseBase):
     for fail."""
 
     # If no test sequence is specified, use the first training sequence
-    if testSequences == None:
+    if testSequences is None:
       testSequences = trainingSequences
 
     cppTP, pyTP = tps[0], tps[1]

--- a/examples/tp/tp_test.py
+++ b/examples/tp/tp_test.py
@@ -982,7 +982,7 @@ def testSequence(trainingSequences,
                  )
 
   trainingSequences = trainingSequences[0]
-  if testSequences == None: testSequences = trainingSequences
+  if testSequences is None: testSequences = trainingSequences
   inferAcceptablePatterns = acceptablePatterns == []
 
   #--------------------------------------------------------------------------------

--- a/external/linux32/lib/python2.6/site-packages/matplotlib/artist.py
+++ b/external/linux32/lib/python2.6/site-packages/matplotlib/artist.py
@@ -75,7 +75,7 @@ class Artist(object):
         # the _remove_method attribute directly.  This would be a protected
         # attribute if Python supported that sort of thing.  The callback
         # has one parameter, which is the child to be removed.
-        if self._remove_method != None:
+        if self._remove_method is not None:
             self._remove_method(self)
         else:
             raise NotImplementedError('cannot remove artist')

--- a/external/linux32/lib/python2.6/site-packages/matplotlib/axes.py
+++ b/external/linux32/lib/python2.6/site-packages/matplotlib/axes.py
@@ -5430,7 +5430,7 @@ class Axes(martist.Artist):
         # Transform accum if needed
         if bins=='log':
             accum = np.log10(accum+1)
-        elif bins!=None:
+        elif binsis notNone:
             if not iterable(bins):
                 minimum, maximum = min(accum), max(accum)
                 bins-=1 # one less edge than bins
@@ -6565,7 +6565,7 @@ class Axes(martist.Artist):
 
         # Check whether bins or range are given explicitly. In that
         # case do not autoscale axes.
-        binsgiven = (cbook.iterable(bins) or range != None)
+        binsgiven = (cbook.iterable(bins) or range is not None)
 
         # check the version of the numpy
         if np.__version__ < "1.3": # version 1.1 and 1.2

--- a/external/linux32/lib/python2.6/site-packages/matplotlib/backends/backend_cairo.py
+++ b/external/linux32/lib/python2.6/site-packages/matplotlib/backends/backend_cairo.py
@@ -351,7 +351,7 @@ class GraphicsContextCairo(GraphicsContextBase):
 
     def set_dashes(self, offset, dashes):
         self._dashes = offset, dashes
-        if dashes == None:
+        if dashes is None:
             self.ctx.set_dash([], 0)  # switch dashes off
         else:
             self.ctx.set_dash (

--- a/external/linux32/lib/python2.6/site-packages/matplotlib/backends/backend_fltkagg.py
+++ b/external/linux32/lib/python2.6/site-packages/matplotlib/backends/backend_fltkagg.py
@@ -295,7 +295,7 @@ class FigureManagerFltkAgg(FigureManagerBase):
 
         def notify_axes_change(fig):
             'this will be called whenever the current axes is changed'
-            if self.toolbar != None: self.toolbar.update()
+            if self.toolbar is not None: self.toolbar.update()
         self.canvas.figure.add_axobserver(notify_axes_change)
 
     def resize(self, event):
@@ -516,7 +516,7 @@ def save_figure(ptr,base):
     while file_chooser.visible() :
         Fltk.Fl.wait()
     fname=None
-    if(file_chooser.count() and file_chooser.value(0) != None):
+    if(file_chooser.count() and file_chooser.value(0) is not None):
         fname=""
         (status,fname)=Fltk.fl_filename_absolute(fname, 1024, file_chooser.value(0))
 

--- a/external/linux32/lib/python2.6/site-packages/matplotlib/backends/backend_gdk.py
+++ b/external/linux32/lib/python2.6/site-packages/matplotlib/backends/backend_gdk.py
@@ -98,7 +98,7 @@ class RendererGDK(RendererBase):
                 self.gdkDrawable.draw_lines(gc.gdkGC, polygon)
 
     def draw_image(self, x, y, im, bbox, clippath=None, clippath_trans=None):
-        if bbox != None:
+        if bbox is not None:
             l,b,w,h = bbox.bounds
             #rectangle = (int(l), self.height-int(b+h),
             #             int(w), int(h))
@@ -228,7 +228,7 @@ class RendererGDK(RendererBase):
 
         key = (x,y,s,angle,hash(prop))
         imageVert = self.rotated.get(key)
-        if imageVert != None:
+        if imageVert is not None:
             gdrawable.draw_image(ggc, imageVert, 0, 0, x, y, h, w)
             return
 
@@ -237,7 +237,7 @@ class RendererGDK(RendererBase):
         imageFlip = gtk.gdk.Image(type=gdk.IMAGE_FASTEST,
                                   visual=gdrawable.get_visual(),
                                   width=w, height=h)
-        if imageFlip == None or imageBack == None or imageVert == None:
+        if imageFlip is None or imageBack is None or imageVert is None:
             warnings.warn("Could not renderer vertical text")
             return
         imageFlip.set_colormap(self._cmap)
@@ -272,7 +272,7 @@ class RendererGDK(RendererBase):
 
         key = self.dpi, s, hash(prop)
         value = self.layoutd.get(key)
-        if value != None:
+        if value is not None:
             return value
 
         size = prop.get_size_in_points() * self.dpi / 96.0
@@ -376,7 +376,7 @@ class GraphicsContextGDK(GraphicsContextBase):
     def set_dashes(self, dash_offset, dash_list):
         GraphicsContextBase.set_dashes(self, dash_offset, dash_list)
 
-        if dash_list == None:
+        if dash_list is None:
             self.gdkGC.line_style = gdk.LINE_SOLID
         else:
             pixels = self.renderer.points_to_pixels(npy.asarray(dash_list))

--- a/external/linux32/lib/python2.6/site-packages/matplotlib/backends/backend_macosx.py
+++ b/external/linux32/lib/python2.6/site-packages/matplotlib/backends/backend_macosx.py
@@ -306,7 +306,7 @@ class FigureManagerMac(_macosx.FigureManager, FigureManagerBase):
 
         def notify_axes_change(fig):
             'this will be called whenever the current axes is changed'
-            if self.toolbar != None: self.toolbar.update()
+            if self.toolbar is not None: self.toolbar.update()
         self.canvas.figure.add_axobserver(notify_axes_change)
 
         # This is ugly, but this is what tkagg and gtk are doing.

--- a/external/linux32/lib/python2.6/site-packages/matplotlib/backends/backend_qt.py
+++ b/external/linux32/lib/python2.6/site-packages/matplotlib/backends/backend_qt.py
@@ -36,7 +36,7 @@ def draw_if_interactive():
     """
     if matplotlib.is_interactive():
         figManager =  Gcf.get_active()
-        if figManager != None:
+        if figManager is not None:
             figManager.canvas.draw()
 
 def _create_qApp():
@@ -65,7 +65,7 @@ def show():
     if DEBUG: print 'Inside show'
 
     figManager =  Gcf.get_active()
-    if figManager != None:
+    if figManager is not None:
         figManager.canvas.draw()
 
     if _create_qApp.qAppCreatedHere:
@@ -254,7 +254,7 @@ class FigureManagerQT( FigureManagerBase ):
 
         def notify_axes_change( fig ):
            # This will be called whenever the current axes is changed
-           if self.toolbar != None: self.toolbar.update()
+           if self.toolbar is not None: self.toolbar.update()
         self.canvas.figure.add_axobserver( notify_axes_change )
 
     def _widgetclosed( self ):
@@ -322,7 +322,7 @@ class NavigationToolbar2QT( NavigationToolbar2, qt.QWidget ):
         basedir = os.path.join(matplotlib.rcParams[ 'datapath' ],'images')
 
         for text, tooltip_text, image_file, callback in self.toolitems:
-            if text == None:
+            if text is None:
                 self.layout.addSpacing( 8 )
                 continue
 
@@ -477,9 +477,9 @@ def exception_handler( type, value, tb ):
     """
     msg = ''
     # get the filename attribute if available (for IOError)
-    if hasattr(value, 'filename') and value.filename != None:
+    if hasattr(value, 'filename') and value.filename is not None:
         msg = value.filename + ': '
-    if hasattr(value, 'strerror') and value.strerror != None:
+    if hasattr(value, 'strerror') and value.strerror is not None:
         msg += value.strerror
     else:
         msg += str(value)

--- a/external/linux32/lib/python2.6/site-packages/matplotlib/backends/backend_qt4.py
+++ b/external/linux32/lib/python2.6/site-packages/matplotlib/backends/backend_qt4.py
@@ -36,7 +36,7 @@ def draw_if_interactive():
     """
     if matplotlib.is_interactive():
         figManager =  Gcf.get_active()
-        if figManager != None:
+        if figManager is not None:
             figManager.canvas.draw()
 
 def _create_qApp():
@@ -65,7 +65,7 @@ def show():
     if DEBUG: print 'Inside show'
 
     figManager =  Gcf.get_active()
-    if figManager != None:
+    if figManager is not None:
         figManager.canvas.draw()
 
     if _create_qApp.qAppCreatedHere:
@@ -242,7 +242,7 @@ class FigureManagerQT( FigureManagerBase ):
 
         def notify_axes_change( fig ):
            # This will be called whenever the current axes is changed
-           if self.toolbar != None: self.toolbar.update()
+           if self.toolbar is not None: self.toolbar.update()
         self.canvas.figure.add_axobserver( notify_axes_change )
 
     def _widgetclosed( self ):
@@ -551,9 +551,9 @@ def exception_handler( type, value, tb ):
     """
     msg = ''
     # get the filename attribute if available (for IOError)
-    if hasattr(value, 'filename') and value.filename != None:
+    if hasattr(value, 'filename') and value.filename is not None:
         msg = value.filename + ': '
-    if hasattr(value, 'strerror') and value.strerror != None:
+    if hasattr(value, 'strerror') and value.strerror is not None:
         msg += value.strerror
     else:
         msg += str(value)

--- a/external/linux32/lib/python2.6/site-packages/matplotlib/backends/backend_tkagg.py
+++ b/external/linux32/lib/python2.6/site-packages/matplotlib/backends/backend_tkagg.py
@@ -358,7 +358,7 @@ class FigureManagerTkAgg(FigureManagerBase):
 
         def notify_axes_change(fig):
             'this will be called whenever the current axes is changed'
-            if self.toolbar != None: self.toolbar.update()
+            if self.toolbar is not None: self.toolbar.update()
         self.canvas.figure.add_axobserver(notify_axes_change)
 
 

--- a/external/linux32/lib/python2.6/site-packages/matplotlib/backends/backend_wx.py
+++ b/external/linux32/lib/python2.6/site-packages/matplotlib/backends/backend_wx.py
@@ -335,7 +335,7 @@ class RendererWx(RendererBase):
         gc.unselect()
 
     def draw_image(self, x, y, im, bbox, clippath=None, clippath_trans=None):
-        if bbox != None:
+        if bbox is not None:
             l,b,w,h = bbox.bounds
         else:
             l=0
@@ -396,7 +396,7 @@ class RendererWx(RendererBase):
         """
         # This is a dirty hack to allow anything with access to a renderer to
         # access the current graphics context
-        assert self.gc != None, "gc must be defined"
+        assert self.gc is not None, "gc must be defined"
         return self.gc
 
 
@@ -1464,7 +1464,7 @@ class FigureManagerWx(FigureManagerBase):
         self.toolbar = self.tb  # consistent with other backends
         def notify_axes_change(fig):
             'this will be called whenever the current axes is changed'
-            if self.tb != None: self.tb.update()
+            if self.tb is not None: self.tb.update()
         self.canvas.figure.add_axobserver(notify_axes_change)
 
         def showfig(*args):
@@ -1922,7 +1922,7 @@ class NavigationToolbarWx(wx.ToolBar):
         """
         DEBUG_MSG("set_active()", 1, self)
         self._ind = ind
-        if ind != None:
+        if ind is not None:
             self._active = [ self._axes[i] for i in self._ind ]
         else:
             self._active = []

--- a/external/linux32/lib/python2.6/site-packages/matplotlib/contour.py
+++ b/external/linux32/lib/python2.6/site-packages/matplotlib/contour.py
@@ -137,7 +137,7 @@ class ContourLabeler:
         self.labelIndiceList = indices
 
         self.labelFontProps = font_manager.FontProperties()
-        if fontsize == None:
+        if fontsize is None:
             font_size = int(self.labelFontProps.get_size_in_points())
         else:
             if type(fontsize) not in [int, float, str]:
@@ -151,7 +151,7 @@ class ContourLabeler:
                     font_size = fontsize
         self.labelFontSizeList = [font_size] * len(levels)
 
-        if _colors == None:
+        if _colors is None:
             self.labelMappable = self
             self.labelCValueList = np.take(self.cvalues, self.labelIndiceList)
         else:
@@ -1070,7 +1070,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
         # sufficiently well that the time is not noticeable.
         # Nonetheless, improvements could probably be made.
 
-        if indices==None:
+        if indicesisNone:
             indices = range(len(self.levels))
 
         dmin = 1e10

--- a/external/linux32/lib/python2.6/site-packages/matplotlib/image.py
+++ b/external/linux32/lib/python2.6/site-packages/matplotlib/image.py
@@ -466,7 +466,7 @@ class NonUniformImage(AxesImage):
         raise NotImplementedError('Method not supported')
 
     def set_interpolation(self, s):
-        if s != None and not s in ('nearest','bilinear'):
+        if s is not None and not s in ('nearest','bilinear'):
             raise NotImplementedError('Only nearest neighbor and bilinear interpolations are supported')
         AxesImage.set_interpolation(self, s)
 

--- a/external/linux32/lib/python2.6/site-packages/matplotlib/lines.py
+++ b/external/linux32/lib/python2.6/site-packages/matplotlib/lines.py
@@ -281,7 +281,7 @@ class Line2D(Artist):
         yt = xy[:, 1]
 
         # Convert pick radius from points to pixels
-        if self.figure == None:
+        if self.figure is None:
             warning.warn('no figure set when check if mouse is on line')
             pixels = self.pickradius
         else:

--- a/external/linux32/lib/python2.6/site-packages/matplotlib/mlab.py
+++ b/external/linux32/lib/python2.6/site-packages/matplotlib/mlab.py
@@ -1833,11 +1833,11 @@ def frange(xini,xfin=None,delta=None,**kw):
     # funny logic to allow the *first* argument to be optional (like range())
     # This was modified with a simpler version from a similar frange() found
     # at http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/66472
-    if xfin == None:
+    if xfin is None:
         xfin = xini + 0.0
         xini = 0.0
 
-    if delta == None:
+    if delta is None:
         delta = 1.0
 
     # compute # of points, spacing and return final list

--- a/external/linux32/lib/python2.6/site-packages/matplotlib/patches.py
+++ b/external/linux32/lib/python2.6/site-packages/matplotlib/patches.py
@@ -2033,7 +2033,7 @@ class FancyBboxPatch(Patch):
 
         """
 
-        if boxstyle==None:
+        if boxstyleisNone:
             return BoxStyle.pprint_styles()
 
         if isinstance(boxstyle, BoxStyle._Base):
@@ -3332,7 +3332,7 @@ class FancyArrowPatch(Patch):
         available styles as a list of strings.
         """
 
-        if connectionstyle==None:
+        if connectionstyleisNone:
             return ConnectionStyle.pprint_styles()
 
         if isinstance(connectionstyle, ConnectionStyle._Base):
@@ -3368,7 +3368,7 @@ class FancyArrowPatch(Patch):
         available box styles as a list of strings.
         """
 
-        if arrowstyle==None:
+        if arrowstyleisNone:
             return ArrowStyle.pprint_styles()
 
         if isinstance(arrowstyle, ConnectionStyle._Base):

--- a/external/linux32/lib/python2.6/site-packages/matplotlib/text.py
+++ b/external/linux32/lib/python2.6/site-packages/matplotlib/text.py
@@ -1176,7 +1176,7 @@ class TextWithDash(Text):
         """
         Get the rotation of the dash in degrees.
         """
-        if self._dashrotation == None:
+        if self._dashrotation is None:
             return self.get_rotation()
         else:
             return self._dashrotation

--- a/external/linux32/lib/python2.6/site-packages/matplotlib/widgets.py
+++ b/external/linux32/lib/python2.6/site-packages/matplotlib/widgets.py
@@ -1105,7 +1105,7 @@ class RectangleSelector:
 
         # If no button was pressed yet ignore the event if it was out
         # of the axes
-        if self.eventpress == None:
+        if self.eventpress is None:
             return event.inaxes!= self.ax
 
         # If a button was pressed, check if the release-button is the

--- a/scripts/temporal_memory_performance_benchmark.py
+++ b/scripts/temporal_memory_performance_benchmark.py
@@ -157,7 +157,7 @@ class TemporalMemoryPerformanceBenchmark(object):
   def _feedOne(pattern, instance, computeFn):
     start = time.clock()
 
-    if pattern == None:
+    if pattern is None:
       instance.reset()
     else:
       computeFn(pattern, instance)

--- a/src/nupic/data/aggregator.py
+++ b/src/nupic/data/aggregator.py
@@ -78,7 +78,7 @@ def initFilter(input, filterInfo = None):
   filterList = []
   for i, fieldName in enumerate(input.getFieldNames()):
     fieldFilter = filterInfo.get(fieldName, None)
-    if fieldFilter == None:
+    if fieldFilter is None:
       continue
 
     var = dict()
@@ -96,10 +96,10 @@ def initFilter(input, filterInfo = None):
 
     elif fieldFilter['type'] == 'number':
 
-      if min != None and max != None:
+      if min is not None and max is not None:
         fp = lambda x: (x['value'] != SENTINEL_VALUE_FOR_MISSING_DATA and \
                         x['value'] >= x['min'] and x['value'] <= x['max'])
-      elif min != None:
+      elif min is not None:
         fp = lambda x: (x['value'] != SENTINEL_VALUE_FOR_MISSING_DATA and \
                         x['value'] >= x['min'])
       else:
@@ -156,7 +156,7 @@ def _aggr_sum(inList):
   the mean value
   """
   aggrMean = _aggr_mean(inList)
-  if aggrMean == None:
+  if aggrMean is None:
     return None
 
   aggrSum = 0
@@ -572,7 +572,7 @@ class Aggregator(object):
       #print self._inIdx, record
 
       # Apply the filter, ignore the record if any field is unacceptable
-      if self._filter != None and not self._filter[0](self._filter[1], record):
+      if self._filter is not None and not self._filter[0](self._filter[1], record):
         return (None, None)
 
       # If no aggregation info just return as-is
@@ -593,7 +593,7 @@ class Aggregator(object):
       #
       t = record[self._timeFieldIdx]
 
-      if self._firstSequenceStartTime == None:
+      if self._firstSequenceStartTime is None:
         self._firstSequenceStartTime = t
 
       # Create initial startTime and endTime if needed

--- a/src/nupic/data/file_record_stream.py
+++ b/src/nupic/data/file_record_stream.py
@@ -507,7 +507,7 @@ class FileRecordStream(RecordStreamIface):
     # Collect stats only once per File object, use fresh csv iterator
     # to keep the next() method returning sequential records no matter when
     # caller asks for stats
-    if self._stats == None:
+    if self._stats is None:
       # Stats are only available when reading csv file
       assert self._mode == self._FILE_READ_MODE
 
@@ -538,10 +538,10 @@ class FileRecordStream(RecordStreamIface):
                 types[i] in [FieldMetaType.integer, FieldMetaType.float] and
                 f not in self._missingValues):
               value = self._adapters[i](f)
-              if self._stats['max'][i] == None or \
+              if self._stats['max'][i] is None or \
                  self._stats['max'][i] < value:
                 self._stats['max'][i] = value
-              if self._stats['min'][i] == None or \
+              if self._stats['min'][i] is None or \
                  self._stats['min'][i] > value:
                 self._stats['min'][i] = value
 

--- a/src/nupic/data/generators/sequence_machine.py
+++ b/src/nupic/data/generators/sequence_machine.py
@@ -60,7 +60,7 @@ class SequenceMachine(object):
     sequence = []
 
     for number in numbers:
-      if number == None:
+      if number is None:
         sequence.append(number)
       else:
         pattern = self.patternMachine.get(number)
@@ -102,7 +102,7 @@ class SequenceMachine(object):
     for i in xrange(len(sequence)):
       pattern = sequence[i]
 
-      if pattern == None:
+      if pattern is None:
         text += "<reset>"
         if i < len(sequence) - 1:
           text += "\n"

--- a/src/nupic/data/joiner.py
+++ b/src/nupic/data/joiner.py
@@ -156,7 +156,7 @@ class WeatherJoiner(object):
         Check to see if this was a blank row in the data files, put in
         placeholder values if it was
         '''
-        if recordsDict == None:
+        if recordsDict is None:
           missingRecords += 1
           # Specifies the missing data placeholder
           line.extend([9999] * len(self.weatherTypes))

--- a/src/nupic/data/record_stream.py
+++ b/src/nupic/data/record_stream.py
@@ -370,10 +370,10 @@ class RecordStreamIface(object):
     value will be None.
     """
     stats = self.getStats()
-    if stats == None:
+    if stats is None:
       return None
     minValues = stats.get('min', None)
-    if minValues == None:
+    if minValues is None:
       return None
     index = self.getFieldNames().index(fieldName)
     return minValues[index]
@@ -387,10 +387,10 @@ class RecordStreamIface(object):
     value will be None.
     """
     stats = self.getStats()
-    if stats == None:
+    if stats is None:
       return None
     maxValues = stats.get('max', None)
-    if maxValues == None:
+    if maxValues is None:
       return None
     index = self.getFieldNames().index(fieldName)
     return maxValues[index]

--- a/src/nupic/data/stream_reader.py
+++ b/src/nupic/data/stream_reader.py
@@ -170,7 +170,7 @@ class StreamReader(RecordStreamIface):
     # Column names must be provided in the streamdef json
     # Special case is ['*'], meaning all available names from the record stream
     self._streamFieldNames = sourceDict.get('columns', None)
-    if self._streamFieldNames != None and self._streamFieldNames[0] == '*':
+    if self._streamFieldNames is not None and self._streamFieldNames[0] == '*':
       self._needFieldsFiltering = False
     else:
       self._needFieldsFiltering = True

--- a/src/nupic/encoders/adaptivescalar.py
+++ b/src/nupic/encoders/adaptivescalar.py
@@ -91,8 +91,8 @@ class AdaptiveScalarEncoder(ScalarEncoder):
     TODO: document
     """
     #If the stats are not fully formed, ignore.
-    if fieldStats[fieldName]['min'] == None or \
-      fieldStats[fieldName]['max'] == None:
+    if fieldStats[fieldName]['min'] is None or \
+      fieldStats[fieldName]['max'] is None:
         return
     self.minval = fieldStats[fieldName]['min']
     self.maxval = fieldStats[fieldName]['max']

--- a/src/nupic/encoders/delta.py
+++ b/src/nupic/encoders/delta.py
@@ -66,7 +66,7 @@ class DeltaEncoder(AdaptiveScalarEncoder):
       output[0:self.n] = 0
     else:
       #make the first delta zero so that the delta ranges are not messed up.
-      if self._prevAbsolute==None:
+      if self._prevAbsoluteisNone:
         self._prevAbsolute= input
       delta = input - self._prevAbsolute
       self._adaptiveScalarEnc.encodeIntoArray(delta, output, learn)
@@ -96,11 +96,11 @@ class DeltaEncoder(AdaptiveScalarEncoder):
     """[ScalarEncoder class method override]"""
 
     #Decode to delta scalar
-    if self._prevAbsolute==None or self._prevDelta==None:
+    if self._prevAbsoluteisNone or self._prevDeltaisNone:
       return [EncoderResult(value=0, scalar=0,
                              encoding=numpy.zeros(self.n))]
     ret = self._adaptiveScalarEnc.topDownCompute(encoded)
-    if self._prevAbsolute != None:
+    if self._prevAbsolute is not None:
       ret = [EncoderResult(value=ret[0].value+self._prevAbsolute,
                           scalar=ret[0].scalar+self._prevAbsolute,
                           encoding=ret[0].encoding)]

--- a/src/nupic/frameworks/opf/metrics.py
+++ b/src/nupic/frameworks/opf/metrics.py
@@ -1135,7 +1135,7 @@ class MetricTwoGram(AggregateMetric):
     # Get the prediction based on the previously known ground truth
     # If no previous, just default to "" or 0, depending on the groundTruth
     #  data type.
-    if prevGTKey == None:
+    if prevGTKey is None:
       if isinstance(actualGroundTruth,str):
         pred = ""
       else:

--- a/src/nupic/frameworks/opf/opfbasicenvironment.py
+++ b/src/nupic/frameworks/opf/opfbasicenvironment.py
@@ -286,7 +286,7 @@ class BasicDatasetReader(DatasetReaderIface):
 
   def next(self):
     row = self._reader.getNextRecordDict()
-    if row == None:
+    if row is None:
       raise StopIteration
 
     return row

--- a/src/nupic/regions/RecordSensor.py
+++ b/src/nupic/regions/RecordSensor.py
@@ -485,13 +485,13 @@ class RecordSensor(PyRegion):
       return 1
 
     elif name == "dataOut":
-      if self.encoder == None:
+      if self.encoder is None:
         raise Exception("NuPIC requested output element count for 'dataOut' on a "
                         "RecordSensor node, but the encoder has not been set")
       return self.encoder.getWidth()
 
     elif name == "sourceOut":
-      if self.encoder == None:
+      if self.encoder is None:
         raise Exception("NuPIC requested output element count for 'sourceOut' "
                         "on a RecordSensor node, but the encoder has not been set")
       return len(self.encoder.getDescription())
@@ -500,7 +500,7 @@ class RecordSensor(PyRegion):
       return self.numCategories
 
     elif name == 'spatialTopDownOut' or name == 'temporalTopDownOut':
-      if self.encoder == None:
+      if self.encoder is None:
         raise Exception("NuPIC requested output element count for 'sourceOut' "
                         "on a RecordSensor node, but the encoder has not been set")
       return len(self.encoder.getDescription())

--- a/src/nupic/regions/SVMClassifierNode.py
+++ b/src/nupic/regions/SVMClassifierNode.py
@@ -319,7 +319,7 @@ class SVMClassifierNode(PyNode, MemoryAwareness):
     else:
       auxVector = numpy.array([])
 
-    if self._auxInputLen == None:
+    if self._auxInputLen is None:
       self._auxInputLen = len(auxVector)
 
     # Initialize data structures the first time

--- a/src/nupic/swarming/HypersearchV2.py
+++ b/src/nupic/swarming/HypersearchV2.py
@@ -2780,7 +2780,7 @@ class HypersearchV2(object):
     # Get min number of particles per swarm from either permutations file or
     # config.
     self._minParticlesPerSwarm = vars.get('minParticlesPerSwarm')
-    if self._minParticlesPerSwarm  == None:
+    if self._minParticlesPerSwarm  is None:
       self._minParticlesPerSwarm = Configuration.get(
                                       'nupic.hypersearch.minParticlesPerSwarm')
     self._minParticlesPerSwarm = int(self._minParticlesPerSwarm)

--- a/src/nupic/swarming/exp_generator/ExpGenerator.py
+++ b/src/nupic/swarming/exp_generator/ExpGenerator.py
@@ -1831,7 +1831,7 @@ def _generateMetricSpecs(options):
 
 
     # Custom Error Metric
-    if not options["customErrorMetric"] == None :
+    if not options["customErrorMetric"] is None :
       #If errorWindow is not specified, make it equal to the default window
       if not "errorWindow" in options["customErrorMetric"]:
         options["customErrorMetric"]["errorWindow"] = metricWindow
@@ -2004,7 +2004,7 @@ def expGenerator(args):
   # -----------------------------------------------------------------
   # Check for use of mutually-exclusive options
   #
-  activeOptions = filter(lambda x: getattr(options, x) != None,
+  activeOptions = filter(lambda x: getattr(options, x) is not None,
                          ('description', 'showSchema'))
   if len(activeOptions) > 1:
     raise _InvalidCommandArgException(

--- a/src/nupic/swarming/permutations_runner.py
+++ b/src/nupic/swarming/permutations_runner.py
@@ -602,7 +602,7 @@ class _HyperSearchRunner(object):
 
       # Sleep before next check
       if not hyperSearchFinished:
-        if self._options["timeout"] != None:
+        if self._options["timeout"] is not None:
           if ((datetime.now() - lastUpdateTime) >
               timedelta(minutes=self._options["timeout"])):
             print "Timeout reached, exiting"

--- a/tests/integration/nupic/algorithms/tp_likelihood_test.py
+++ b/tests/integration/nupic/algorithms/tp_likelihood_test.py
@@ -275,7 +275,7 @@ class TPLikelihoodTest(testcasebase.TestCaseBase):
     allTrainingPatterns = trainingSet[2]
 
     trainingCummulativeFrequencies = numpy.cumsum(trainingFrequencies)
-    if testSequences == None:
+    if testSequences is None:
       testSequences = trainingSequences
 
     # Learn

--- a/tests/integration/nupic/algorithms/tp_overlapping_sequences_test.py
+++ b/tests/integration/nupic/algorithms/tp_overlapping_sequences_test.py
@@ -358,7 +358,7 @@ def evalSequences(tps,
   """
 
   # If no test sequence is specified, use the first training sequence
-  if testSequences == None:
+  if testSequences is None:
     testSequences = trainingSequences
 
   # First TP instance is used by default for verbose printing of input values,

--- a/tests/integration/nupic/algorithms/tp_segment_learning.py
+++ b/tests/integration/nupic/algorithms/tp_segment_learning.py
@@ -315,7 +315,7 @@ class ExperimentTestBaseClass(testcasebase.TestCaseBase):
     for fail."""
 
     # If no test sequence is specified, use the first training sequence
-    if testSequences == None:
+    if testSequences is None:
       testSequences = trainingSequences
 
     cppTP, pyTP = tps[0], tps[1]

--- a/tests/integration/nupic/algorithms/tp_test.py
+++ b/tests/integration/nupic/algorithms/tp_test.py
@@ -986,7 +986,7 @@ def _testSequence(trainingSequences,
                  )
 
   trainingSequences = trainingSequences[0]
-  if testSequences == None: testSequences = trainingSequences
+  if testSequences is None: testSequences = trainingSequences
   inferAcceptablePatterns = acceptablePatterns == []
 
   #--------------------------------------------------------------------------------

--- a/tests/integration/nupic/data/aggregation_test.py
+++ b/tests/integration/nupic/data/aggregation_test.py
@@ -127,7 +127,7 @@ class DataOutputMyFile(object):
 
 
   def appendRecord(self, record, inputRef):
-    if self._file == None:
+    if self._file is None:
       print 'No File'
     self._file.appendRecord(record)
 

--- a/tests/regression/run_opf_benchmarks_test.py
+++ b/tests/regression/run_opf_benchmarks_test.py
@@ -362,7 +362,7 @@ class OPFBenchmarkRunner(unittest.TestCase):
 
   @classmethod
   def setTrainFraction(cls, x):
-    if x == None:
+    if x is None:
       cls.__trainFraction==1.0
     elif x > 1.0 or x < 0.0:
       raise Exception("Invalid training fraction")
@@ -1116,7 +1116,7 @@ class OPFBenchmarkRunner(unittest.TestCase):
     if self.__maxPermutations > 0:
       maxPermutations = "--maxPermutations={0:d}".format(self.__maxPermutations)
       runString.append(maxPermutations)
-    if self.__timeout != None:
+    if self.__timeout is not None:
       timeout = "--timeout={0:d}".format(self.__timeout)
       runString.append(timeout)
     if self.__doEnsemble:
@@ -1152,7 +1152,7 @@ class OPFBenchmarkRunner(unittest.TestCase):
     if self.__maxPermutations > 0:
       maxPermutations = "--maxPermutations={0:d}".format(self.__maxPermutations)
       runString.append(maxPermutations)
-    if self.__timeout != None:
+    if self.__timeout is not None:
       timeout = "--timeout={0:d}".format(self.__timeout)
       runString.append(timeout)
     if self.__doEnsemble:
@@ -1186,7 +1186,7 @@ class OPFBenchmarkRunner(unittest.TestCase):
     if self.__maxPermutations > 0:
       maxPermutations = "--maxPermutations={0:d}".format(self.__maxPermutations)
       runString.append(maxPermutations)
-    if self.__timeout != None:
+    if self.__timeout is not None:
       timeout = "--timeout={0:d}".format(self.__timeout)
       runString.append(timeout)
     if self.__doEnsemble:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:nupic?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:nupic?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
